### PR TITLE
Changed Bed Anchors

### DIFF
--- a/objects/peglaci/loungeables/peglacibed/peglacibed.object
+++ b/objects/peglaci/loungeables/peglacibed/peglacibed.object
@@ -42,7 +42,7 @@
       "animationCycle" : 1.0,
 
       "spaceScan" : 0.1,
-      "anchors" : [ "bottom" ],
+      "anchors" : [ "background" ],
       "collision" : "platform"
     }
   ]


### PR DESCRIPTION
Changed from "Bottom" to "Background" as the bed is carved/recessed into the back wall, it shouldn't need any support from the floor, it should get it from the walls it's in/around.
![screenshot 5](https://user-images.githubusercontent.com/32578904/31312974-d7864a30-aba1-11e7-98f5-7a8f972fd69f.png)
_You can now do this._
