### PR TITLE
Tweaks Peglaci tile zlevels

### DIFF
--- a/tiles/materials/giants/peglacigiantek.material
+++ b/tiles/materials/giants/peglacigiantek.material
@@ -22,6 +22,6 @@
     "lightTransparent" : false,
     "occludesBelow" : true,
     "multiColored" : true,
-    "zLevel" : 0
+    "zLevel" : 2985
   }
 }

--- a/tiles/materials/peglaci/peglacialloyscreen.material
+++ b/tiles/materials/peglaci/peglacialloyscreen.material
@@ -21,7 +21,7 @@
     "lightTransparent" : false,
     "occludesBelow" : false,
     "multiColored" : false,
-    "zLevel" : 6001,
+    "zLevel" : 3017,
     "radiantLight" : [0, 50, 50]
   }
 }

--- a/tiles/materials/peglaci/peglacicableconnector.material
+++ b/tiles/materials/peglaci/peglacicableconnector.material
@@ -20,6 +20,6 @@
     "lightTransparent" : false,
     "occludesBelow" : true,
     "multiColored" : false,
-    "zLevel" : 3000
+    "zLevel" : 2997
   }
 }

--- a/tiles/materials/peglaci/peglacicablenexus.material
+++ b/tiles/materials/peglaci/peglacicablenexus.material
@@ -20,6 +20,6 @@
     "lightTransparent" : false,
     "occludesBelow" : true,
     "multiColored" : false,
-    "zLevel" : 481
+    "zLevel" : 2998
   }
 }

--- a/tiles/materials/peglaci/peglacicablepipe.material
+++ b/tiles/materials/peglaci/peglacicablepipe.material
@@ -1,5 +1,5 @@
 {
-  "materialId" : 3515,
+  "materialId" : 2994,
   "materialName" : "peglacicablepipe",
   "particleColor" : [111, 75, 58, 255],
   "itemDrop" : "peglacicablepipe",
@@ -19,6 +19,6 @@
     "lightTransparent" : false,
     "occludesBelow" : false,
     "multiColored" : true,
-    "zLevel" : 482
+    "zLevel" : 2994
   }
 }

--- a/tiles/materials/peglaci/peglacidrainblock.material
+++ b/tiles/materials/peglaci/peglacidrainblock.material
@@ -22,6 +22,6 @@
     "lightTransparent" : true,
     "occludesBelow" : false,
     "multiColored" : true,
-    "zLevel" : 4000
+    "zLevel" : 3020
   }
 }

--- a/tiles/materials/peglaci/peglacihexpane.material
+++ b/tiles/materials/peglaci/peglacihexpane.material
@@ -21,6 +21,6 @@
     "lightTransparent" : true,
     "occludesBelow" : false,
     "multiColored" : true,
-    "zLevel" : 480
+    "zLevel" : 2991
   }
 }

--- a/tiles/materials/peglaci/peglacihorcable.material
+++ b/tiles/materials/peglaci/peglacihorcable.material
@@ -20,6 +20,6 @@
     "lightTransparent" : false,
     "occludesBelow" : true,
     "multiColored" : false,
-    "zLevel" : 0
+    "zLevel" : 2996
   }
 }

--- a/tiles/materials/peglaci/peglaciicecolumn.material
+++ b/tiles/materials/peglaci/peglaciicecolumn.material
@@ -20,6 +20,6 @@
     "lightTransparent" : false,
     "occludesBelow" : true,
     "multiColored" : false,
-    "zLevel" : 500
+    "zLevel" : 3007
   }
 }

--- a/tiles/materials/peglaci/peglacimetalblock.material
+++ b/tiles/materials/peglaci/peglacimetalblock.material
@@ -21,6 +21,6 @@
     "lightTransparent" : false,
     "occludesBelow" : true,
     "multiColored" : false,
-    "zLevel" : 3000
+    "zLevel" : 3013
   }
 }

--- a/tiles/materials/peglaci/peglacimetalpanel.material
+++ b/tiles/materials/peglaci/peglacimetalpanel.material
@@ -21,6 +21,6 @@
     "lightTransparent" : false,
     "occludesBelow" : true,
     "multiColored" : false,
-    "zLevel" : 500
+    "zLevel" : 3024
   }
 }

--- a/tiles/materials/peglaci/peglacimetalscreen.material
+++ b/tiles/materials/peglaci/peglacimetalscreen.material
@@ -21,6 +21,6 @@
     "lightTransparent" : false,
     "occludesBelow" : true,
     "multiColored" : false,
-    "zLevel" : 0
+    "zLevel" : 3016
   }
 }

--- a/tiles/materials/peglaci/peglacislopedmetal.material
+++ b/tiles/materials/peglaci/peglacislopedmetal.material
@@ -21,6 +21,6 @@
     "lightTransparent" : false,
     "occludesBelow" : false,
     "multiColored" : true,
-    "zLevel" : 5001
+    "zLevel" : 5000
   }
 }

--- a/tiles/materials/peglaci/peglacivertcable.material
+++ b/tiles/materials/peglaci/peglacivertcable.material
@@ -19,6 +19,6 @@
     "lightTransparent" : false,
     "occludesBelow" : true,
     "multiColored" : true,
-    "zLevel" : 0
+    "zLevel" : 2995
   }
 }

--- a/tiles/materials/pykrete/peglaciinscribedpykreteblock.material
+++ b/tiles/materials/pykrete/peglaciinscribedpykreteblock.material
@@ -20,6 +20,6 @@
     "lightTransparent" : false,
     "occludesBelow" : true,
     "multiColored" : true,
-    "zLevel" : 510
+    "zLevel" : 3002
   }
 }

--- a/tiles/materials/pykrete/peglacipykreteblock.material
+++ b/tiles/materials/pykrete/peglacipykreteblock.material
@@ -21,6 +21,6 @@
     "lightTransparent" : false,
     "occludesBelow" : true,
     "multiColored" : true,
-    "zLevel" : 500
+    "zLevel" : 3001
   }
 }

--- a/tiles/materials/pykrete/peglacipykretedecor.material
+++ b/tiles/materials/pykrete/peglacipykretedecor.material
@@ -20,6 +20,6 @@
     "lightTransparent" : false,
     "occludesBelow" : true,
     "multiColored" : true,
-    "zLevel" : 485
+    "zLevel" : 3006
   }
 }

--- a/tiles/materials/pykrete/peglacipykretefoundation.material
+++ b/tiles/materials/pykrete/peglacipykretefoundation.material
@@ -19,6 +19,6 @@
     "lightTransparent" : false,
     "occludesBelow" : true,
     "multiColored" : true,
-    "zLevel" : 3000
+    "zLevel" : 3010
   }
 }

--- a/tiles/materials/pykrete/peglacipykretestrip.material
+++ b/tiles/materials/pykrete/peglacipykretestrip.material
@@ -19,6 +19,6 @@
     "lightTransparent" : false,
     "occludesBelow" : true,
     "multiColored" : true,
-    "zLevel" : 485
+    "zLevel" : 3005
   }
 }

--- a/tiles/materials/pykrete/peglacislopedpykrete.material
+++ b/tiles/materials/pykrete/peglacislopedpykrete.material
@@ -22,6 +22,6 @@
     "lightTransparent" : false,
     "occludesBelow" : false,
     "multiColored" : true,
-    "zLevel" : 5000
+    "zLevel" : 4999
   }
 }


### PR DESCRIPTION
Fixes #41 
See expanded commit or changes for new zlevels.
Interesting fact: Peglaci tile IDs were chosen because of how it'd make them layer if they were all on the same zlevel, which, while neat, is *really not the proper way to do that*.

Some zlevel reference numbers:

- Avali tiles occupy the 2000-2300 range
- Elithian Alliance tiles occupy the 0-400 range
- Most sloped tiles are somewhere around 5000
- Vanilla tiles range from 0 to 4000, with placement relatively random
- Dirt specifically is at 1920; most "natural ground" materials are lower