### PR TITLE
Fixes small peglaci monitors being excessively shifted

### DIFF
--- a/objects/peglaci/wired/shipscreen/peglacishipscreen.object
+++ b/objects/peglaci/wired/shipscreen/peglacishipscreen.object
@@ -44,8 +44,8 @@
       "spaceScan" : 0.1,
       "anchors" : [ "background" ],
       
-      "lightPosition" : [0, 1],
-      "beamAngle" : 225
+      "lightPosition" : [1, 1],
+      "beamAngle" : 180
     },
     {
       "image" : "peglacishipscreen.png:<color>.<frame>",
@@ -57,8 +57,8 @@
       "spaceScan" : 0.1,
       "anchors" : [ "background" ],
       
-      "lightPosition" : [0, 1],
-      "beamAngle" : 270
+      "lightPosition" : [-2, 1],
+      "beamAngle" : 0
     }
   ],
 

--- a/objects/peglaci/wired/shipscreen2/peglacishipscreen2.object
+++ b/objects/peglaci/wired/shipscreen2/peglacishipscreen2.object
@@ -44,8 +44,8 @@
       "spaceScan" : 0.1,
       "anchors" : [ "background" ],
       
-      "lightPosition" : [0, 1],
-      "beamAngle" : 225
+      "lightPosition" : [-1, 1],
+      "beamAngle" : 270
     },
     {
       "image" : "peglacishipscreen2.png:<color>.<frame>",
@@ -57,7 +57,7 @@
       "spaceScan" : 0.1,
       "anchors" : [ "background" ],
       
-      "lightPosition" : [0, 1],
+      "lightPosition" : [-1, 1],
       "beamAngle" : 270
     }
   ],

--- a/objects/peglaci/wired/shipscreensmall/peglacishipscreensmall.object
+++ b/objects/peglaci/wired/shipscreensmall/peglacishipscreensmall.object
@@ -57,8 +57,8 @@
       "spaceScan" : 0.1,
       "anchors" : [ "background" ],
       
-      "lightPosition" : [0, 1],
-      "beamAngle" : 270
+      "lightPosition" : [-1, 1],
+      "beamAngle" : 315
     }
   ],
 

--- a/objects/peglaci/wired/shipscreensmall/peglacishipscreensmall.object
+++ b/objects/peglaci/wired/shipscreensmall/peglacishipscreensmall.object
@@ -35,11 +35,11 @@
   "orientations" : [
     {
       "image" : "peglacishipscreensmall.png:<color>.<frame>",
-      "imagePosition" : [-16, 0],
+      "imagePosition" : [-8, 0],
       
       "direction" : "left",
       "flipImages" : true,
-      "animationPosition" : [-16, 0],
+      "animationPosition" : [-8, 0],
       
       "spaceScan" : 0.1,
       "anchors" : [ "background" ],
@@ -49,10 +49,10 @@
     },
     {
       "image" : "peglacishipscreensmall.png:<color>.<frame>",
-      "imagePosition" : [-16, 0],
+      "imagePosition" : [-8, 0],
       
       "direction" : "right",
-      "animationPosition" : [-16, 0],
+      "animationPosition" : [-8, 0],
       
       "spaceScan" : 0.1,
       "anchors" : [ "background" ],

--- a/objects/peglaci/wired/shipscreensmall2/peglacishipscreensmall2.object
+++ b/objects/peglaci/wired/shipscreensmall2/peglacishipscreensmall2.object
@@ -57,8 +57,8 @@
       "spaceScan" : 0.1,
       "anchors" : [ "background" ],
       
-      "lightPosition" : [0, 1],
-      "beamAngle" : 270
+      "lightPosition" : [-1, 1],
+      "beamAngle" : 315
     }
   ],
 

--- a/objects/peglaci/wired/shipscreensmall2/peglacishipscreensmall2.object
+++ b/objects/peglaci/wired/shipscreensmall2/peglacishipscreensmall2.object
@@ -35,11 +35,11 @@
   "orientations" : [
     {
       "image" : "peglacishipscreensmall2.png:<color>.<frame>",
-      "imagePosition" : [-16, 0],
+      "imagePosition" : [-8, 0],
       
       "direction" : "left",
       "flipImages" : true,
-      "animationPosition" : [-16, 0],
+      "animationPosition" : [-8, 0],
       
       "spaceScan" : 0.1,
       "anchors" : [ "background" ],
@@ -49,10 +49,10 @@
     },
     {
       "image" : "peglacishipscreensmall2.png:<color>.<frame>",
-      "imagePosition" : [-16, 0],
+      "imagePosition" : [-8, 0],
       
       "direction" : "right",
-      "animationPosition" : [-16, 0],
+      "animationPosition" : [-8, 0],
       
       "spaceScan" : 0.1,
       "anchors" : [ "background" ],

--- a/objects/peglaci/wired/shipscreensmall3/peglacishipscreensmall3.object
+++ b/objects/peglaci/wired/shipscreensmall3/peglacishipscreensmall3.object
@@ -35,11 +35,11 @@
   "orientations" : [
     {
       "image" : "peglacishipscreensmall3.png:<color>.<frame>",
-      "imagePosition" : [-16, 0],
+      "imagePosition" : [-8, 0],
       
       "direction" : "left",
       "flipImages" : true,
-      "animationPosition" : [-16, 0],
+      "animationPosition" : [-8, 0],
       
       "spaceScan" : 0.1,
       "anchors" : [ "background" ],
@@ -49,10 +49,10 @@
     },
     {
       "image" : "peglacishipscreensmall3.png:<color>.<frame>",
-      "imagePosition" : [-16, 0],
+      "imagePosition" : [-8, 0],
       
       "direction" : "right",
-      "animationPosition" : [-16, 0],
+      "animationPosition" : [-8, 0],
       
       "spaceScan" : 0.1,
       "anchors" : [ "background" ],

--- a/objects/peglaci/wired/shipscreensmall3/peglacishipscreensmall3.object
+++ b/objects/peglaci/wired/shipscreensmall3/peglacishipscreensmall3.object
@@ -57,8 +57,8 @@
       "spaceScan" : 0.1,
       "anchors" : [ "background" ],
       
-      "lightPosition" : [0, 1],
-      "beamAngle" : 270
+      "lightPosition" : [-1, 1],
+      "beamAngle" : 315
     }
   ],
 


### PR DESCRIPTION
They will no longer require an extra open tile of space to the right.

Also, monitor light directions are now consistent:
4x3 monitors aim straight left/right
3x2 monitors aim straight down
2x2 monitors aim diagonally down left/right